### PR TITLE
fix: add error handling and make git hook executable

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -130,7 +130,18 @@ func (c *Command) InstallHook() error {
 
 	target := path.Join(strings.TrimSpace(string(hookPath)), HookPrepareCommitMessageFile)
 
-	return os.WriteFile(target, []byte(HookPrepareCommitMessageTemplate), 0o600)
+	err = os.WriteFile(target, []byte(HookPrepareCommitMessageTemplate), 0o600)
+	if err != nil {
+		return err
+	}
+
+	// Set executable permission
+	err = os.Chmod(target, 0o755)
+	if err != nil {
+		return fmt.Errorf("failed to set executable permission: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Command) UninstallHook() error {


### PR DESCRIPTION
- Add error handling and set executable permission for the git hook file